### PR TITLE
setMaxCurrentShunt normalization optimized

### DIFF
--- a/INA226.cpp
+++ b/INA226.cpp
@@ -232,23 +232,24 @@ int INA226::setMaxCurrentShunt(float maxCurrent, float shunt, bool normalize)
 
     uint16_t factor = 1;  // 1u to 1000u
     uint8_t i = 0;        // 1 byte loop reduces footprint
+    bool result = false;
     do{
       if( 1*factor >= currentLSB_uA){
         _current_LSB = 1*factor * 1e-6;
-        i=0xFF;
+        result = true;
       }else if( 2*factor >= currentLSB_uA){
         _current_LSB = 2*factor * 1e-6;
-        i=0xFF;
+        result = true;
       }else if( 5*factor >= currentLSB_uA){
         _current_LSB = 5*factor * 1e-6;
-        i=0xFF;
+        result = true;
       }else {
         factor *= 10;
         i++;
       }
-    }while(i < 4); // 10^4 
+    }while(i < 4 and !result); // 10^4 
 
-    if(i != 0xFF) {
+    if(!result) {
       _current_LSB = 0;
       return INA226_ERR_NORMALIZE_FAILED;
     }
@@ -266,7 +267,7 @@ int INA226::setMaxCurrentShunt(float maxCurrent, float shunt, bool normalize)
   while (calib > 65535)
   {
     _current_LSB *= 2;
-    calib = calib >> 1;
+    calib >>= 1;
   }
   _writeRegister(INA226_CALIBRATION, calib);
 

--- a/INA226.h
+++ b/INA226.h
@@ -42,6 +42,12 @@
 //  See issue #26
 #define INA226_MINIMAL_SHUNT             (0.001)
 
+// set normalization factor for currentLSB in setMaxCurrentShunt
+// 2.5 ... 2.5, 5.0, 7.5, 10.0, 25, 50, 75, 100, 250, ... 1000 [uA] 
+// 5.0 ... 5.0, 10, 50, 100, 500, 1000 [uA]
+// 10.0 ... 10, 100, 1000 [uA]
+// do not use other values than 2.5, 5.0 or 10.0 
+#define INA226_CURRENTLSB_FACTOR        2.5
 
 class INA226
 {
@@ -91,7 +97,7 @@ public:
   //  shunt * maxCurrent < 81 mV
   //  maxCurrent >= 0.001
   //  shunt      >= 0.001
-  int      setMaxCurrentShunt(float macCurrent = 20.0,
+  int      setMaxCurrentShunt(float maxCurrent = 20.0,
                               float shunt = 0.002,
                               bool normalize = true);
   bool     isCalibrated()     { return _current_LSB != 0.0; };

--- a/INA226.h
+++ b/INA226.h
@@ -37,17 +37,10 @@
 #define INA226_ERR_SHUNTVOLTAGE_HIGH     0x8000
 #define INA226_ERR_MAXCURRENT_LOW        0x8001
 #define INA226_ERR_SHUNT_LOW             0x8002
-
+#define INA226_ERR_NORMALIZE_FAILED      0x8003
 
 //  See issue #26
 #define INA226_MINIMAL_SHUNT             (0.001)
-
-// set normalization factor for currentLSB in setMaxCurrentShunt
-// 2.5 ... 2.5, 5.0, 7.5, 10.0, 25, 50, 75, 100, 250, ... 1000 [uA] 
-// 5.0 ... 5.0, 10, 50, 100, 500, 1000 [uA]
-// 10.0 ... 10, 100, 1000 [uA]
-// do not use other values than 2.5, 5.0 or 10.0 
-#define INA226_CURRENTLSB_FACTOR        2.5
 
 class INA226
 {


### PR DESCRIPTION
Hello Rob, thank you very much for your INA226 LIB! It is essential for my little DIY project and a great help! Thank you for sharing it!

I think there is a bug in setMaxCurrentShunt at the normalization code. After normalization _current_LSB is less than before.

setMaxCurrentShunt(8, 0.01, true )
normalize:	 true
initial current_LSB:	0.00024414 uA / bit
Prescale current_LSB:	0.00024416 uA / bit
factor:	10000
Final current_LSB:	0.00010000 uA / bit
Calibration:	5120
Max current:	3.28 A
Shunt:	0.01000000 ohm
ShuntV:	0.0800 Volt

setMaxCurrentShunt(20, 0.002, true )
normalize:	 true
initial current_LSB:	0.00061035 uA / bit
Prescale current_LSB:	0.00061040 uA / bit
factor:	10000
Final current_LSB:	0.00010000 uA / bit
Calibration:	25600
Max current:	3.28 A
Shunt:	0.00200000 ohm
ShuntV:	0.0400 Volt

There would be an easy fix by changing '_current_LSB = 1.0 / factor;" to '_current_LSB = 10.0 / factor;" at line 235.

Never the less I thought, the normalization could be less greedy and more flexible. I hope you like it!

Best regards,
Armin